### PR TITLE
Fix for left pane layout

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -97,12 +97,10 @@ span.highlight {
 }
 
 div.about {
-  margin-left: 10px;
-  position: fixed;
-  left: 0px;
-  bottom: 0px;
-
-  width: 290px;
+  font-size: .8em;
+  margin-top: 40px;
+  border: 2px solid #666;
+  padding: 10px;
 }
 
 .hidden-select-setting {


### PR DESCRIPTION
This addresses a bug where the text in the "about" panel overlaps the controls above when the browser window is under 1000px tall. 
<img width="1193" alt="text overap" src="https://user-images.githubusercontent.com/1048438/96053752-fcf5fd80-0e34-11eb-9398-db404bb9c400.png">

This avoids the overlap and styles the about text panel differently so it stays out of the way.
<img width="321" alt="Cleaned up left panel" src="https://user-images.githubusercontent.com/1048438/96053827-30388c80-0e35-11eb-879e-e808b09951b1.png">

